### PR TITLE
component-type-fixed

### DIFF
--- a/src/constant/component-db.ts
+++ b/src/constant/component-db.ts
@@ -27,7 +27,7 @@ export const COMPONENTS_DB: {
 `,
         },
       ],
-      type: "components:ui",
+      type: "registry:ui",
     },
   },
 };


### PR DESCRIPTION
- The PR updates the `type` field in the `COMPONENTS_DB` constant from `"components:ui"` to `"registry:ui"`.
- This change ensures consistency with the expected naming conventions in the system or registry.
- No other modifications were made in the file, `src/constant/component-db.ts`.
- Suggested audits for instances using the old type to ensure uniformity across the codebase.
- Recommendations made to define component types as constants or enums to minimize errors and facilitate future modifications.
- It's advised to add a comment for clarity regarding the rationale behind changing the type to `"registry:ui"` for future developers.
- Overall, the summary emphasizes the importance of type refinement for clearer code structure.