### PR TITLE
small fix to solve confusion of dependencies

### DIFF
--- a/src/constant/component-db.ts
+++ b/src/constant/component-db.ts
@@ -28,26 +28,22 @@ export const COMPONENTS_DB: {
         {
           type: "registry:component",
           path: `components/unknownbug-ui/pages/auth-page.tsx`,
-          content: authPage,
+          content: JSON.stringify(authPage),
         },
       ],
       type: "registry:component",
     },
     "docs-page-1": {
       name: "Documentation Page",
-      dependencies: [
-        "resizable",
-        "input",
-        "tabs",
-        "label",
+      dependencies: ["resizable", "input", "tabs", "label"],
+      registryDependencies: [
         "https://ui.unknownbug.tech/api/components/Code/markdown-renderer-1",
       ],
-      registryDependencies: [],
       files: [
         {
           type: "registry:component",
           path: `components/unknownbug-ui/pages/documentation-page.tsx`,
-          content: docsPage,
+          content: JSON.stringify(docsPage),
         },
       ],
       type: "registry:component",
@@ -62,7 +58,7 @@ export const COMPONENTS_DB: {
         {
           type: "registry:component",
           path: `components/unknownbug-ui/comp/markdown-renderer.tsx`,
-          content: markdownRenderer,
+          content: JSON.stringify(markdownRenderer),
         },
       ],
       type: "registry:component",


### PR DESCRIPTION
- This PR modifies the `COMPONENTS_DB` constants to store component source code using `JSON.stringify`, enhancing the data structure for storage and transmission.
- Key components like `authPage`, `docsPage`, and `markdownRenderer` are now serialized, ensuring uniform handling downstream.
- A correction was made to reposition `"https://ui.unknownbug.tech/api/components/Code/markdown-renderer-1"` from an empty `registryDependencies` array to an active status for the `docs-page-1` component.
- Other structural and naming aspects remain unchanged.
- Suggested improvements include:
  - Adding validation to check serializability of components before JSON conversion.
  - Auditing other components for uniform structure in their dependencies fields.
  - Enhancing documentation with inline comments regarding the rationale for serialized contents.
  - Considering performance optimizations like lazy loading for larger serialized contents.
- Overall, changes support clarity and consistency in how components and their dependencies are handled within the application.